### PR TITLE
Updated install.sh and update-hyprland.sh to better remove debian HL pkgs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+## 13 February 2026
+
+- Updated Discord Link
+- Removed JakooLit ko-fi, wallet, etc
+- Removed stargazer star graph
+- Updated `uninstall.sh` to remove compiled pkgs as well as deb pkgs
+- Updated hyprwire to v0.3.0
+
 ## 11 February 2026
 
 - Moved hyprland dependencies to 00-dependencies script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## CHANGELOG
 
+## 21 February 2026
+
+- Enhanced Hyprland debian package cleanup in `install.sh`
+  - Some Hyprland packages weren't getting removed 
+- Added `--pacakge-cleanup` option to `update-hyprland.sh`
+  - Source building is the supported method because:
+    - deb packages could be removed from testing/unstable at anytime w/o notice
+    - The packages might not updated for some time
+    - Not currently available for debian 13 stable branch
+- Updated documentation
+
 ## 13 February 2026
 
 - Updated Discord Link

--- a/Debian-Hyprland-Install-Upgrade.es.md
+++ b/Debian-Hyprland-Install-Upgrade.es.md
@@ -53,6 +53,7 @@ Flags clave:
 - --force-update: sobrescribe valores fijados en hypr-tags.env (equivalente a FORCE=1)
 - --dry-run / --install: solo compilar o compilar+instalar
 - --only / --skip: limitar qué módulos se ejecutan
+- --package-cleanup: purga el stack Hyprland de Debian antes de compilar
 - --build-trixie / --no-trixie: habilita/deshabilita el modo de compatibilidad Debian 13 (auto-detectado por defecto)
 
 #### dry-run-build.sh
@@ -78,10 +79,12 @@ Este repo incluye varios "flags de control" que afectan cómo se compila/instala
 - `--only <lista>` / `--skip <lista>`: ejecutar solo un subconjunto de módulos
 - `--fetch-latest`: consulta GitHub Releases y refresca etiquetas
 - `--force-update`: sobrescribe valores fijados en `hypr-tags.env` (equivalente a `FORCE=1`)
+- `--package-cleanup`: purga paquetes Hyprland de Debian antes de compilar
 - `--build-trixie` / `--no-trixie`: habilita/deshabilita modo de compatibilidad Debian 13
 
 Notas:
 - Cuando el modo trixie está habilitado, `update-hyprland.sh` exporta `HYPR_BUILD_TRIXIE=1` y reenvía `--build-trixie` a los scripts de módulos.
+- `--package-cleanup` elimina paquetes Hyprland de Debian para evitar versiones mezcladas (Hyprland, hyprutils/lang/graphics/cursor/wire, aquamarine, soporte Qt, guiutils, apps como hypridle/lock/picker/paper/sunset/launcher/systeminfo, hyprpm/hyprctl y xdg-desktop-portal-hyprland).
 
 ### Flags de install.sh
 
@@ -184,6 +187,12 @@ Ahora, este método automáticamente:
 ```bash
 # Instala solo Hyprland y componentes esenciales
 ./update-hyprland.sh --install
+```
+
+Si antes instalaste Hyprland desde los repos de Debian, usa limpieza de paquetes primero:
+
+```bash
+./update-hyprland.sh --package-cleanup --install
 ```
 
 ### Método 3: Instalación Nueva con Últimas Versiones

--- a/Debian-Hyprland-Install-Upgrade.md
+++ b/Debian-Hyprland-Install-Upgrade.md
@@ -53,6 +53,7 @@ Key flags:
 - --force-update: override pinned values in hypr-tags.env (equivalent to FORCE=1)
 - --dry-run / --install: compile-only or compile+install
 - --only / --skip: limit which modules run
+- --package-cleanup: purge Debian-packaged Hyprland stack before building
 - --build-trixie / --no-trixie: enable/disable Debian 13 (trixie) compatibility mode (auto-detected by default)
 
 #### dry-run-build.sh
@@ -78,10 +79,12 @@ This repo provides several "control flags" that affect how the stack is built. T
 - `--only <list>` / `--skip <list>`: run a subset of modules
 - `--fetch-latest`: query GitHub Releases and refresh tags
 - `--force-update`: override pinned values in `hypr-tags.env` (equivalent to `FORCE=1`)
+- `--package-cleanup`: purge Debian Hyprland packages before building
 - `--build-trixie` / `--no-trixie`: enable/disable Debian 13 compatibility mode
 
 Notes:
 - When trixie mode is enabled, `update-hyprland.sh` exports `HYPR_BUILD_TRIXIE=1` and forwards `--build-trixie` to module scripts.
+- `--package-cleanup` removes Debian-provided Hyprland packages to avoid mixed versions (Hyprland, hyprutils/lang/graphics/cursor/wire, aquamarine, qt support, guiutils, tools/apps like hypridle/lock/picker/paper/sunset/launcher/systeminfo, hyprpm/hyprctl, and xdg-desktop-portal-hyprland).
 
 ### install.sh flags
 
@@ -184,6 +187,12 @@ This method now automatically:
 ```bash
 # Install only Hyprland and essential components
 ./update-hyprland.sh --install
+```
+
+If you previously installed Hyprland from Debian repos, run with package cleanup first:
+
+```bash
+./update-hyprland.sh --package-cleanup --install
 ```
 
 ### Method 3: Fresh Installation with Latest Versions

--- a/README.md
+++ b/README.md
@@ -105,10 +105,7 @@ sudo nano /etc/apt/sources.list
 - Debian now builds Hyprland v0.53.2!
     - This requires the just released `Debian-Hyprland v2.9.4` installer
     - Debian 13 (`Trixie`, aka `Stable`)
-    - While it does now support v0.53.2
-            - At this time it should not be used for production
-            - Testing is on going but NVIDIA GPUs have not been tested
-            - Intel, AMD, and in VMs only so far
+    - While it does now support v0.53.2 - At this time it should not be used for production - Testing is on going but NVIDIA GPUs have not been tested - Intel, AMD, and in VMs only so far
     - Debian Testing (`Forky`) and Unstable (`SID`) - Build and run Hyprland v0.53.2 without issue
 
 - 10 October 2025 Update!
@@ -332,24 +329,6 @@ cd ~/Debian-Hyprland
 
 - Subscribe to my Youtube Channel [YouTube](https://www.youtube.com/@Ja.KooLit)
 
-- you can also give support through coffee's or btc 😊
-
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/jakoolit)
-
-or
-
-[!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/JaKooLit)
-
-Or you can donate cryto on my btc wallet :)
-
-> 1N3MeV2dsX6gQB42HXU6MF2hAix1mqjo8i
-
-![Bitcoin](https://github.com/user-attachments/assets/7ed32f8f-c499-46f0-a53c-3f6fbd343699)
-
 #### 📹 Youtube videos (Click to view and watch the playlist) 📹
 
 [![Youtube Playlist Thumbnail](https://raw.githubusercontent.com/JaKooLit/screenshots/main/Youtube.png)](https://youtube.com/playlist?list=PLDtGd5Fw5_GjXCznR0BzCJJDIQSZJRbxx&si=iaNjLulFdsZ6AV-t)
-
-## 🥰🥰 💖💖 👍👍👍
-
-[![Stargazers over time](https://starchart.cc/JaKooLit/Debian-Hyprland.svg?variant=adaptive)](https://starchart.cc/JaKooLit/Debian-Hyprland)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/assets/latte.png" width="400" />
 </p>
 
-![GitHub Repo stars](https://img.shields.io/github/stars/JaKooLit/Debian-Hyprland?style=for-the-badge&color=cba6f7) ![GitHub last commit](https://img.shields.io/github/last-commit/JaKooLit/Debian-Hyprland?style=for-the-badge&color=b4befe) ![GitHub repo size](https://img.shields.io/github/repo-size/JaKooLit/Debian-Hyprland?style=for-the-badge&color=cba6f7) <a href="https://discord.gg/kool-tech-world"> <img src="https://img.shields.io/discord/1151869464405606400?style=for-the-badge&logo=discord&color=cba6f7&link=https%3A%2F%2Fdiscord.gg%kool-tech-world"> </a>
+![GitHub Repo stars](https://img.shields.io/github/stars/JaKooLit/Debian-Hyprland?style=for-the-badge&color=cba6f7) ![GitHub last commit](https://img.shields.io/github/last-commit/JaKooLit/Debian-Hyprland?style=for-the-badge&color=b4befe) ![GitHub repo size](https://img.shields.io/github/repo-size/JaKooLit/Debian-Hyprland?style=for-the-badge&color=cba6f7) <a href="https://discord.gg/RZJgC7KAKm"> <img src="https://img.shields.io/discord/1151869464405606400?style=for-the-badge&logo=discord&color=cba6f7&link=https%3A%2F%2Fdiscord.gg%kool-tech-world"> </a>
 
 <br/>
 </div>

--- a/install-scripts/02-pre-cleanup.sh
+++ b/install-scripts/02-pre-cleanup.sh
@@ -19,14 +19,45 @@ PACKAGES=(
 # List of packages installed from Debian-Hyprland repo
 uninstall=(
   hyprland
-  xdg-desktop-portal-hyprland
-  libhhyprland-dev
+  hyprland-plugins
+  hyprland-session
+  hyprland-protocols
+  hyprland-guiutils
+  hyprland-qt-support
+  hyprland-qtutils
+  hyprutils
   libhyprutils-dev
   libhyprutils0
+  hyprlang
+  libhyprlang-dev
+  libhyprlang0
+  hyprgraphics
+  libhyprgraphics-dev
+  libhyprgraphics0
+  hyprcursor
+  libhyprcursor-dev
+  libhyprcursor0
   hyprwayland-scanner
-  hyprland-protocols
+  hyprtoolkit
+  hyprwire
+  hyprwire-protocols
+  libhyprwire-dev
+  libhyprwire0
+  aquamarine
+  libaquamarine-dev
+  libaquamarine0
+  hypridle
+  hyprlock
+  hyprpicker
+  hyprpaper
+  hyprsunset
+  hyprlauncher
+  hyprsysteminfo
+  hyprpolkitagent
   hyprctl
   hyprpm
+  xdg-desktop-portal-hyprland
+  libhhyprland-dev
   Hyprland
 )
 

--- a/install.sh
+++ b/install.sh
@@ -323,18 +323,33 @@ printf "\n%.0s" {1..1}
 clean_existing_hyprland() {
     echo "${INFO} Checking for existing Hyprland installations..." | tee -a "$LOG"
 
-    # List of Hyprland-related packages and binaries to check
-    local hyprland_packages=("hyprland" "hyprutils" "hyprgraphics" "hyprcursor" "hyprtoolkit" "hyprland-guiutils" "hyprwire" "aquamarine" "hypridle" "hyprlock" "hyprpolkitagent" "hyprpicker" "xdg-desktop-portal-hyprland" "hyprland-plugins")
+    # List of Hyprland-related packages to remove if installed via Debian repos
+    local hyprland_packages=(
+        hyprland hyprland-plugins hyprland-session
+        hyprland-protocols hyprland-guiutils hyprland-qt-support hyprland-qtutils
+        hyprutils libhyprutils0 libhyprutils-dev
+        hyprlang libhyprlang0 libhyprlang-dev
+        hyprgraphics libhyprgraphics0 libhyprgraphics-dev
+        hyprcursor libhyprcursor0 libhyprcursor-dev
+        hyprwayland-scanner
+        hyprtoolkit
+        hyprwire hyprwire-protocols libhyprwire0 libhyprwire-dev
+        aquamarine libaquamarine0 libaquamarine-dev
+        hypridle hyprlock hyprpicker hyprpaper hyprsunset hyprlauncher hyprsysteminfo
+        hyprpolkitagent hyprpm hyprctl
+        xdg-desktop-portal-hyprland
+    )
     local hyprland_binaries=("/usr/local/bin/Hyprland" "/usr/local/bin/hyprland" "/usr/bin/Hyprland" "/usr/bin/hyprland")
 
     # Remove installed .deb packages
     echo "${INFO} Removing any previously installed .deb packages..." | tee -a "$LOG"
     for pkg in "${hyprland_packages[@]}"; do
-        if dpkg -l | grep -q "^ii.*$pkg"; then
-            echo "${NOTE} Removing package: $pkg" | tee -a "$LOG"
-            sudo apt-get remove -y "$pkg" 2>&1 | grep -E "(Setting up|Removing)" | tee -a "$LOG" || true
+        if dpkg -s "$pkg" >/dev/null 2>&1; then
+            echo "${NOTE} Purging package: $pkg" | tee -a "$LOG"
+            sudo apt-get purge -y "$pkg" 2>&1 | grep -E "(Setting up|Removing|Purging)" | tee -a "$LOG" || true
         fi
     done
+    sudo apt-get autoremove -y >/dev/null 2>&1 || true
 
     # Remove binaries built from source
     echo "${INFO} Checking for binaries built from source..." | tee -a "$LOG"
@@ -658,6 +673,8 @@ echo "${INFO} Running a ${SKY_BLUE}full system update...${RESET}" | tee -a "$LOG
 sudo apt update
 
 sleep 1
+# Remove any Debian-provided Hyprland stack packages before source builds
+clean_existing_hyprland
 # execute pre clean up
 execute_script "02-pre-cleanup.sh"
 

--- a/update-hyprland.sh
+++ b/update-hyprland.sh
@@ -18,6 +18,7 @@
 #   ./update-hyprland.sh --with-deps --dry-run
 #   ./update-hyprland.sh --fetch-latest --via-helper   # use dry-run-build.sh for a summary-only run
 #   ./update-hyprland.sh --force-update --install      # override pinned versions (equivalent to FORCE=1)
+#   ./update-hyprland.sh --package-cleanup --install   # purge Debian Hyprland packages before building
 #   ./update-hyprland.sh --help                        # show this help
 #
 # Notes:
@@ -32,6 +33,37 @@ LOG_DIR="$REPO_ROOT/Install-Logs"
 mkdir -p "$LOG_DIR"
 TS=$(date +%F-%H%M%S)
 SUMMARY_LOG="$LOG_DIR/update-hypr-$TS.log"
+# Remove Debian-provided Hyprland stack packages before source builds (install only)
+remove_deb_hypr_packages() {
+    local pkgs=(
+        hyprland hyprland-plugins hyprland-session
+        hyprland-protocols hyprland-guiutils hyprland-qt-support hyprland-qtutils
+        hyprutils libhyprutils0 libhyprutils-dev
+        hyprlang libhyprlang0 libhyprlang-dev
+        hyprgraphics libhyprgraphics0 libhyprgraphics-dev
+        hyprcursor libhyprcursor0 libhyprcursor-dev
+        hyprwayland-scanner
+        hyprtoolkit
+        hyprwire hyprwire-protocols libhyprwire0 libhyprwire-dev
+        aquamarine libaquamarine0 libaquamarine-dev
+        hypridle hyprlock hyprpicker hyprpaper hyprsunset hyprlauncher hyprsysteminfo
+        hyprpolkitagent hyprpm hyprctl
+        xdg-desktop-portal-hyprland
+    )
+    local found=()
+    for p in "${pkgs[@]}"; do
+        if dpkg -s "$p" >/dev/null 2>&1; then
+            found+=("$p")
+        fi
+    done
+    if [[ ${#found[@]} -eq 0 ]]; then
+        echo "[INFO] No Debian Hyprland packages detected." | tee -a "$SUMMARY_LOG"
+        return 0
+    fi
+    echo "[INFO] Purging Debian Hyprland packages: ${found[*]}" | tee -a "$SUMMARY_LOG"
+    sudo apt-get purge -y "${found[@]}" | tee -a "$SUMMARY_LOG" || true
+    sudo apt-get autoremove -y >/dev/null 2>&1 || true
+}
 
 # Default module order (core first, then Hyprland)
 DEFAULT_MODULES=(
@@ -72,6 +104,7 @@ USE_SYSTEM_LIBS=1
 AUTO_FALLBACK=0
 MINIMAL=0
 FORCE_UPDATE=0
+PACKAGE_CLEANUP=0
 ONLY_LIST=""
 SKIP_LIST=""
 SET_ARGS=()
@@ -101,6 +134,7 @@ Options:
       --system          Prefer system-installed hypr* libraries (default)
       --via-helper      Use dry-run-build.sh to summarize a dry-run
       --minimal         Build minimal stack before hyprland
+      --package-cleanup Purge Debian Hyprland packages before building
       --no-fetch        Do not auto-fetch tags on install
       --build-trixie    Force Debian 13 (trixie) compatibility mode (enables needed shims)
       --no-trixie       Disable trixie compatibility mode
@@ -641,6 +675,10 @@ while [[ $# -gt 0 ]]; do
         VIA_HELPER=1
         shift
         ;;
+    --package-cleanup)
+        PACKAGE_CLEANUP=1
+        shift
+        ;;
     --no-fetch)
         NO_FETCH=1
         shift
@@ -716,9 +754,18 @@ if [[ $FETCH_LATEST -eq 1 ]]; then
 fi
 
 # Run the stack
+# If only cleanup was requested, perform it and exit (no build).
+if [[ $PACKAGE_CLEANUP -eq 1 && $DO_INSTALL -eq 0 && $DO_DRY_RUN -eq 0 ]]; then
+    remove_deb_hypr_packages
+    exit 0
+fi
 if [[ $DO_DRY_RUN -eq 0 && $DO_INSTALL -eq 0 ]]; then
     echo "[INFO] No build option specified. Defaulting to --dry-run." | tee -a "$SUMMARY_LOG"
     DO_DRY_RUN=1
+fi
+# Before install builds, optionally remove Debian-provided Hyprland stack to avoid mixed versions
+if [[ $DO_INSTALL -eq 1 && $PACKAGE_CLEANUP -eq 1 ]]; then
+    remove_deb_hypr_packages
 fi
 
 # If using helper, delegate to dry-run-build.sh for summary-only output


### PR DESCRIPTION
# Pull Request

## Description
## 21 February 2026

- Enhanced Hyprland debian package cleanup in `install.sh`
  - Some Hyprland packages weren't getting removed 
- Added `--pacakge-cleanup` option to `update-hyprland.sh`
  - Source building is the supported method because:
    - deb packages could be removed from testing/unstable at anytime w/o notice
    - The packages might not updated for some time
    - Not currently available for debian 13 stable branch
- Updated documentation

## Type of change



- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/LinuxBeginnings/Debian-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/LinuxBeginnings/Debian-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.
 
 