### PR TITLE
Fix broken polkit issue in HL dots 

### DIFF
--- a/Debian-Hyprland-Install-Upgrade.md
+++ b/Debian-Hyprland-Install-Upgrade.md
@@ -517,6 +517,24 @@ git ls-remote --tags https://github.com/hyprwm/Hyprland
 # Use confirmed existing tag
 ./update-hyprland.sh --set HYPRLAND=v0.50.1 --install
 ```
+#### GUI Apps via pkexec Fail (Wayland)
+
+**Symptoms**: Password prompt appears but app fails to launch; errors like “Authorization required, but no authorization protocol specified” or “cannot open display”.
+
+**Solutions**:
+
+```bash
+pkexec env -u DISPLAY -u XAUTHORITY \
+  WAYLAND_DISPLAY="$WAYLAND_DISPLAY" \
+  XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+  DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
+  GDK_BACKEND=wayland \
+  QT_QPA_PLATFORM=wayland \
+  <app>
+```
+
+**Notes**:
+- Ensure a Polkit agent is installed and running (this installer includes `xfce-polkit`).
 
 ### Debug Steps
 

--- a/install-scripts/01-hypr-pkgs.sh
+++ b/install-scripts/01-hypr-pkgs.sh
@@ -35,6 +35,8 @@ hypr_package=(
     qt5ct
     qt5-style-kvantum
     qt-style-kvantum-themes
+    qt-style-kvantum
+    qt6-style-kvantum
     qt6ct
     slurp
     swappy
@@ -65,6 +67,7 @@ hypr_package_2=(
     nvtop
     pamixer
     qalculate-gtk
+    xfce-polkit
 )
 
 # packages to force reinstall (only when HYPR_FORCE_REINSTALL=1)

--- a/install.sh
+++ b/install.sh
@@ -917,6 +917,9 @@ if [ -e /usr/local/bin/hyprland ] || [ -f /usr/local/bin/Hyprland ]; then
 
     printf "${SKY_BLUE}Thank you${RESET} 🫰 for using 🇵🇭 ${MAGENTA}KooL's Hyprland Dots${RESET}. ${YELLOW}Enjoy and Have a good day!${RESET}"
     printf "\n%.0s" {1..2}
+    printf "\\n${NOTE} If GUI apps launched with pkexec fail under Wayland, use:\\n"
+    printf "  pkexec env -u DISPLAY -u XAUTHORITY WAYLAND_DISPLAY=\\\"\\$WAYLAND_DISPLAY\\\" XDG_RUNTIME_DIR=\\\"\\$XDG_RUNTIME_DIR\\\" DBUS_SESSION_BUS_ADDRESS=\\\"\\$DBUS_SESSION_BUS_ADDRESS\\\" GDK_BACKEND=wayland QT_QPA_PLATFORM=wayland <app>\\n"
+    printf "\\n%.0s" {1..1}
 
     printf "\n${NOTE} You can start Hyprland by typing ${SKY_BLUE}Hyprland${RESET} (IF SDDM is not installed) (note the capital H!).\n"
     printf "\n${NOTE} However, it is ${YELLOW}highly recommended to reboot${RESET} your system.\n\n"

--- a/pr-13.md
+++ b/pr-13.md
@@ -1,0 +1,90 @@
+# PR #13 Analysis — Debian‑Hyprland (Mar 26, 2026)
+
+## Scope & intent (from PR diff)
+
+## PR #13 modernizes the Hyprland build/install stack for v0.54+ on Debian, standardizes /usr/local prefixes, adds LLVM/Clang 21, and improves cleanup safety in update-hyprland.sh. It targets the development branch.
+
+### Key touched areas:
+
+• Toolchain provisioning in `install-scripts/00-dependencies.sh`
+• Build tool selection in `install-scripts/hyprland.sh`
+• Dependency adjustments in `install-scripts/hyprland-guiutils.sh`
+• Install prefixes moved to `/usr/local` across multiple module scripts
+• New cleanup behavior in `update-hyprland.sh`
+• `hypr-tags.env` update (`HYPRCURSOR_TAG`)
+
+### Benefits
+
+1. Clang 21+ availability for Hyprland v0.54+  
+   The script installs `LLVM/Clang 21` if current `clang <21`, aligning with upstream C++26 requirements. This reduces compile failures for newer Hyprland versions.
+
+2. Safer, more predictable install layout  
+   Standardizing to` /usr/local`` reduces collisions with Debian-packaged /usr libs and headers
+    - Addressing the common “shadowing” issue where older /usr libs override newer /usr/local builds.
+
+3. Cleaner upgrade path  
+   `update-hyprland.sh` now previews orphaned Hyprland files under /usr, asks for confirmation, and supports `--clean` to wipe stale build caches.
+    - This provides a safer cleanup flow and avoids silent `rm -rf`.
+
+4. Modernized LLVM repo handling  
+   Replacing apt-key with signed-by is correct for current Debian APT security posture, and using HTTPS reduces MITM risk.
+
+5. hyprland‑guiutils dependency clarity  
+   The switch from Qt6 to pixman/libdrm/libxkbcommon matches upstream change for v0.2.0+, with explicit comment explaining the rationale.
+
+6. Linker flag ordering fixes  
+   LDFLAGS now place -lhypr\* after -L/usr/local/lib to avoid link-order failures.
+
+## Potential issues / regressions
+
+1. LLVM repo availability per codename  
+   The LLVM repo uses `lsb_release -sc` (e.g., `trixie`,`sid`, `forky`). If LLVM doesn’t publish that codename for `LLVM 21`, the install will fail or break apt-get update.  
+   **Risk:** new dependency source errors on certain Debian suites or future codenames.  
+   **Mitigation:** add a fallback to a known supported codename or skip Clang install if repo is missing.
+
+2. `/usr/local` consistency and runtime lookup  
+   Many modules now install to `/usr/local`, but only some scripts export `PKG_CONFIG_PATH`, `CMAKE_PREFIX_PATH`, etc. (notably `hyprtoolkit` and `hyprland-guiutils`).  
+   **Risk:** later builds may still resolve `/usr headers/libs` if environment isn’t globally set.  
+   **Mitigation:** centralize /usr/local env exports in Global_functions.sh for all module builds.
+
+3. `hyprshutdown.sh` glaze behavior changed  
+   The CMake line removed -DCMAKE_DISABLE_FIND_PACKAGE_glaze=ON when the install prefix was added.  
+   **Risk:** build could now require glaze to be present, potentially failing on systems without it or changing linkage.  
+   **Mitigation:** keep the glaze-disable flag if it was intentionally avoiding a dependency.
+
+4. `hyprland.sh` removal of the Nix stub fallback  
+   The stub was previously used if Nix helper sources were still referenced. It is now removed.  
+   **Risk:** if the Nix patch isn’t applied and the upstream Nix helper still references deps (e.g., glaze JSON), builds could fail.  
+   **Mitigation:** ensure the patch always removes Nix helper references or reintroduce a fallback stub guarded by detection.
+
+5. `hyprland-guiutils` dependency list is tag‑specific  
+   The new deps are correct for v0.2.0+; if a user pins an earlier tag, the Qt6 removal will break builds.  
+   **Mitigation:** gate the dependency list by tag version or document that older tags are unsupported.
+
+6. Orphan cleanup scope  
+   `remove_orphaned_hypr_files` removes non‑dpkg Hypr\* artifacts under /usr.  
+   **Risk:** could delete user‑installed binaries/libs that are intentionally kept in /usr, though it prompts first.  
+   **Mitigation:** keep the prompt (already present) and document the patterns. Consider adding a --list-only option.
+
+## Notable changes worth validating
+
+• `install-scripts/00-dependencies.sh`: LLVM repo setup, keyring creation, and Clang 21 install sequence.
+• `install-scripts/hyprland.sh`: new clang‑21 preference; removal of Nix stub fallback.
+• `install-scripts/hyprland-guiutils.sh`: Qt6 dependency removal; LDFLAGS ordering.
+• `install-scripts/hyprtoolkit.sh`: pkg-config template patching and /usr/local env.
+• `update-hyprland.sh`: --clean, orphaned file preview + confirmation.
+
+## Testing considerations
+
+Suggested test sequence (per PR and repo guidance):
+• `./update-hyprland.sh --with-deps --package-cleanup --clean --install`
+• Also test a pinned tag older than hyprland-guiutils v0.2.0 to confirm deps are aligned or document constraints.
+• Validate a clean install on Trixie with no existing Hypr\* libs in /usr, and an upgrade case with stale /usr libs to ensure cleanup works safely.
+
+## Recommendations before merge
+
+1. Add a fallback or guard for LLVM repo codename availability.
+2. Restore the `glaze` disable flag in hyprshutdown.sh if it was intentional.
+3. Confirm the Nix helper removal path is always safe; otherwise re-add a stub fallback only when needed.
+4. Centralize `/usr/local` build environment exports to reduce accidental `/usr` linkage.
+5. Document tag compatibility for `hyprland-guiutils` deps (`Qt6` vs `pixman` path).


### PR DESCRIPTION
# Pull Request

## Description
Policy kit for elevating access hasn't been working. 
Switched to XFCE-polkit as primary 
for KDE polkit  the kvantum pkgs were missing 



## Type of change

Please put an `x` in the boxes that apply:

- [x ] **Bug fix** (non-breaking change which fixes an issue)
- 
